### PR TITLE
Make dtype configurable in ddpm_v3

### DIFF
--- a/03__diffusion_model/ddpm_v3/data_loader.py
+++ b/03__diffusion_model/ddpm_v3/data_loader.py
@@ -4,6 +4,7 @@ import numpy as np
 from functools import partial
 import tensorflow as tf
 from tensorflow import keras
+from dtype_util import get_compute_dtype
 
 
 class DataLoader:
@@ -76,7 +77,7 @@ class DataLoader:
         
       arr = (arr) *(self.CLIP_MAX-self.CLIP_MIN) + self.CLIP_MIN
       return arr
-    img = tf.numpy_function(_preprocess, [path], tf.float32)
+    img = tf.numpy_function(_preprocess, [path], get_compute_dtype())
     img_size = self.img_size if self.crop_size is None else self.crop_size
     img = tf.ensure_shape(img, [img_size, img_size, None])
     

--- a/03__diffusion_model/ddpm_v3/data_loader_2.py
+++ b/03__diffusion_model/ddpm_v3/data_loader_2.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import numpy as np
 import tensorflow as tf
+from dtype_util import get_compute_dtype
 
 logging.basicConfig(level=logging.INFO)
 
@@ -98,7 +99,7 @@ class DataLoader:
                 self.CLIP_MIN,
                 self.CLIP_MAX,
             )
-        img = tf.numpy_function(_wrapped_preprocess, [path], tf.float32)
+        img = tf.numpy_function(_wrapped_preprocess, [path], get_compute_dtype())
         img_size = self.img_size if self.crop_size is None else self.crop_size
         img = tf.ensure_shape(img, [img_size, img_size, None])
         return img

--- a/03__diffusion_model/ddpm_v3/diffusion_model.py
+++ b/03__diffusion_model/ddpm_v3/diffusion_model.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow import keras
 import tqdm
+from dtype_util import get_compute_dtype
 
 
 class DiffusionModel(keras.Model):
@@ -152,7 +153,7 @@ class DiffusionModel(keras.Model):
         _, img_size, _, img_channel = img_input.shape
         if gen_inputs is None:
             _shape = (num_images, img_size, img_size, img_channel)
-            samples = tf.random.normal(shape=_shape, dtype=tf.float32)
+            samples = tf.random.normal(shape=_shape, dtype=get_compute_dtype())
         else:
             samples = gen_inputs
         n_imgs, _h, _w, _ = samples.shape

--- a/03__diffusion_model/ddpm_v3/diffusion_utils.py
+++ b/03__diffusion_model/ddpm_v3/diffusion_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import tensorflow as tf
 from tensorflow import keras
+from dtype_util import get_compute_dtype
 
 
 class DiffusionUtility:
@@ -46,9 +47,10 @@ class DiffusionUtility:
         mu_coefs = np.sqrt(alphas)
         var_coefs = 1.0 - alphas
         sigma_coefs = np.sqrt(var_coefs)
-        self.mu_coefs = tf.constant(mu_coefs, tf.float32)
-        self.var_coefs = tf.constant(var_coefs, tf.float32)
-        self.sigma_coefs = tf.constant(sigma_coefs, tf.float32)
+        dtype = get_compute_dtype()
+        self.mu_coefs = tf.constant(mu_coefs, dtype)
+        self.var_coefs = tf.constant(var_coefs, dtype)
+        self.sigma_coefs = tf.constant(sigma_coefs, dtype)
 
         alpha_t = alphas[reverse_stride:]
         alpha_s = alphas[0:-reverse_stride]
@@ -67,11 +69,11 @@ class DiffusionUtility:
         reverse_mu_ddpm_x0 = np.insert(reverse_mu_ddpm_x0, 0, [1.0] * reverse_stride)
         reverse_mu_ddim_x0 = np.insert(reverse_mu_ddim_x0, 0, [1.0] * reverse_stride)
         reverse_mu_ddim_noise = np.insert(reverse_mu_ddim_noise, 0, [0.0] * reverse_stride)
-        self.reverse_sigma_coefs = tf.constant(reverse_sigma_coefs, tf.float32)
-        self.reverse_mu_ddpm_xt = tf.constant(reverse_mu_ddpm_xt, tf.float32)
-        self.reverse_mu_ddpm_x0 = tf.constant(reverse_mu_ddpm_x0, tf.float32)
-        self.reverse_mu_ddim_x0 = tf.constant(reverse_mu_ddim_x0, tf.float32)
-        self.reverse_mu_ddim_noise = tf.constant(reverse_mu_ddim_noise, tf.float32)
+        self.reverse_sigma_coefs = tf.constant(reverse_sigma_coefs, dtype)
+        self.reverse_mu_ddpm_xt = tf.constant(reverse_mu_ddpm_xt, dtype)
+        self.reverse_mu_ddpm_x0 = tf.constant(reverse_mu_ddpm_x0, dtype)
+        self.reverse_mu_ddim_x0 = tf.constant(reverse_mu_ddim_x0, dtype)
+        self.reverse_mu_ddim_noise = tf.constant(reverse_mu_ddim_noise, dtype)
 
     def q_sample(self, x_0, t, noise):
         sigma_t = tf.gather(self.sigma_coefs, t)[:, None, None, None]
@@ -116,7 +118,7 @@ class DiffusionUtility:
         return (_mean, _sigma)
 
     def p_sample(self, pred_mean, pred_sigma):
-        noise = tf.random.normal(shape=pred_mean.shape, dtype=tf.float32)
+        noise = tf.random.normal(shape=pred_mean.shape, dtype=get_compute_dtype())
         x_s = pred_mean + pred_sigma * noise
         return x_s
 

--- a/03__diffusion_model/ddpm_v3/dtype_util.py
+++ b/03__diffusion_model/ddpm_v3/dtype_util.py
@@ -1,0 +1,6 @@
+import tensorflow as tf
+
+def get_compute_dtype():
+    """Return current compute dtype from the global mixed precision policy."""
+    policy = tf.keras.mixed_precision.global_policy()
+    return tf.as_dtype(policy.compute_dtype if policy else tf.float32)

--- a/03__diffusion_model/ddpm_v3/layers.py
+++ b/03__diffusion_model/ddpm_v3/layers.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 from tensorflow import keras
+from dtype_util import get_compute_dtype
 
 
 def kernel_init(scale):
@@ -17,7 +18,7 @@ class TimeEmbedding(keras.layers.Layer):
         self.dim = dim
 
     def call(self, inputs):
-        inputs = tf.cast(inputs, dtype=tf.float32)
+        inputs = tf.cast(inputs, dtype=get_compute_dtype())
         if len(inputs.shape) != 1:
             raise ValueError("Input tensor must be 1D.")
         emb = tf.exp(tf.linspace(0.0, 1.0, self.dim // 2) * -tf.math.log(10000.0))


### PR DESCRIPTION
## Summary
- create `dtype_util` helper to read the mixed precision policy
- use configurable dtype when loading datasets and creating constants
- allow `prepare_datasets` to infer dtype
- sample noise and cast values using the current compute dtype

## Testing
- `python -m py_compile dtype_util.py data_loader.py data_loader_2.py diffusion_model.py diffusion_utils.py layers.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f7e2d23c8320b3d942d75c65e987